### PR TITLE
Feat/paginate list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,16 @@ bsh ❯ bb-pr
 Simple tooling that helps management of bitbucket pull requests from
 the commandline
 
-Usage: bb-pr [help|list|squash-msg|squash-merge|approve|unapprove] [options]
+Usage: bb-pr [help|list|squash-msg|squash-merge|approve|unapprove|decline] [options]
   help         : show this help
   list         : list (open) PRs in this repo
   squash-msg   : copy a reasonable message to the clipboard for merging a PR
   squash-merge : merge the PR using the message from 'squash-msg'
   approve      : approve a PR (though should you from the CLI?)
   unapprove    : remove your approval
+  decline      : decline a PR
 
-'squash-msg' | 'squash-merge' | 'approve' | 'unapprove'
+'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline'
 Requires the PR number as its only parameter
 
 'list' can additionally filter by state

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ I realise that I've been quite spoilt by the github cli.
 
 I'd like some way of replicating [gh-squash-merge](https://github.com/quotidian/gh-squash-merge) when playing around with bitbucket PRs.
 
-This is that.
+This is that and also replicates some functionality like `gh pr list`.
 
 ## Setup
 
 - You need to goto repository settings and edit the default description for a pull request such that it looks something like this:
 
-```
+```markdown
 ## Motivation
 
 <!-- What is your motivation for this PR
@@ -28,27 +28,39 @@ This is that.
 
 > This isn't the same as the markers for `gh-squash-merge` because Atlassian doesn't _hide HTML comments_ and it escapes the underscores to avoid CommonMark highlighting. What's illuminating is that when you create a pull request you are subjected to the rich text editor, but edit it later gives you the markdown editor. Nevertheless, people will see your HTML comments, and there's nothing much that can be done to avoid that.
 
-
 - You need to install [jq](https://github.com/jqlang/jq) && [jf](https://github.com/sayanarijit/jf).
-- You need to define some environment variables to control your access to bitbucket
+- You will already have the standard tooling like `curl` | `tr` etc.
+- You need to define some environment variables to control your access to bitbucket (c.f. use [app-passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/))
+  - Remember to give yourself write access to pull requests.
+
+```bash
+export BITBUCKET_USER=my_bitbucket_username
+export BITBUCKET_TOKEN=my_bitbucket_app_password
+```
+
 - Check this repo out, and put it in the path.
 
 ```bash
 bsh ❯ bb-pr
 
-Usage: bb-pr [help|list|squash-msg|squash-merge] [options]
-  help         : show this help
-  list         : list the PRs in this repo
-  squash-msg   : copy a reasonable message to the clipboard for merging a PR
-  squash-merge : merge the PR using the message from 'msg'
+Simple tooling that helps management of bitbucket pull requests from
+the commandline
 
-'squash-msg'
-'squash-merge'
+Usage: bb-pr [help|list|squash-msg|squash-merge|approve|unapprove] [options]
+  help         : show this help
+  list         : list (open) PRs in this repo
+  squash-msg   : copy a reasonable message to the clipboard for merging a PR
+  squash-merge : merge the PR using the message from 'squash-msg'
+  approve      : approve a PR (though should you from the CLI?)
+  unapprove    : remove your approval
+
+'squash-msg' | 'squash-merge' | 'approve' | 'unapprove'
 Requires the PR number as its only parameter
 
-Requires you to have exported 2 environment variables:
-export BITBUCKET_USER=my_bitbucket_username
-export BITBUCKET_TOKEN=my_bitbucket_app_password
-
-c.f. https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/
+'list' can additionally filter by state
+  -s : the state (e.g. -s OPEN) OPEN|MERGED|DECLINED|SUPERSEDED
+       If you get it wrong, you'll get all the PRs which may take
+       longer than you want. Defaults to 'OPEN'
 ```
+
+> We try to derive the correct application for inserting text into clipboard. You can override this using the environment variable `BB_PR_CLIPBOARD`. It's `clip.exe` on WSL2, `xclip` on non WSL linux, undefined for MINGW (wingit) and MacOS (though you should be able to use `pbcopy`). The testing environment is WSL2 (Ubuntu & Debian).

--- a/bb-pr
+++ b/bb-pr
@@ -14,7 +14,7 @@ set -eo pipefail
 BITBUCKET_API_URL="https://api.bitbucket.org/2.0/repositories"
 GIT_REMOTE=$(git remote get-url origin | cut -f2 -d':') || true
 BITBUCKET_SLUG=${GIT_REMOTE%.git}
-ACTION_LIST="help|list|squash-msg|squash-merge|approve|unapprove"
+ACTION_LIST="help|list|squash-msg|squash-merge|approve|unapprove|decline"
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 
 CURL_AUTH="${BITBUCKET_USER}:${BITBUCKET_TOKEN}"
@@ -59,8 +59,9 @@ Usage: $(basename "$0") [$ACTION_LIST] [options]
   squash-merge : merge the PR using the message from 'squash-msg'
   approve      : approve a PR (though should you from the CLI?)
   unapprove    : remove your approval
+  decline      : decline a PR
 
-'squash-msg' | 'squash-merge' | 'approve' | 'unapprove'
+'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline'
 Requires the PR number as its only parameter
 
 'list' can additionally filter by state
@@ -100,6 +101,16 @@ action_list() {
       next=$(echo "$response" | jq --raw-output ".next")
     done
   } | sort | column -s "|" -t -N "ID,TITLE,URL"
+}
+
+action_decline() {
+  local pr_number="$1"
+  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/decline"
+  if [[ -z "$pr_number" ]]; then
+    echo ">>> No PR"
+    exit 1
+  fi
+  curl -X POST $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" | jq --raw-output '"\(.state)"'
 }
 
 

--- a/bb-pr
+++ b/bb-pr
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
+# Requires you to have exported 2 environment variables:
+# export BITBUCKET_USER=my_bitbucket_username
+# export BITBUCKET_TOKEN=my_bitbucket_app_password
+#
+# c.f. https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/
+# Requires:
+# - jq   : https://github.com/jqlang/jq
+# - jf   : https://github.com/sayanarijit/jf (to json encode multiline comments)
+# - curl : why of course it does!, why haven't you got it?
 
 set -eo pipefail
 
 BITBUCKET_API_URL="https://api.bitbucket.org/2.0/repositories"
 GIT_REMOTE=$(git remote get-url origin | cut -f2 -d':') || true
 BITBUCKET_SLUG=${GIT_REMOTE%.git}
-ACTION_LIST="help|list|squash-msg|squash-merge"
+ACTION_LIST="help|list|squash-msg|squash-merge|approve|unapprove"
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 
+CURL_AUTH="${BITBUCKET_USER}:${BITBUCKET_TOKEN}"
+CURL_HEADER_CTYPE="Content-Type: application/json"
+CURL_HEADER_ACCEPT="Accept: application/json"
+CURL_FLAGS="-fsSL"
+
 trap cleanup 1 2 15
-
-curl_wrapper() {
-  curl -fsSL -u"${BITBUCKET_USER}:${BITBUCKET_TOKEN}" -H "Accept: application/json" "$@"
-}
-
-curl_wrapper_post() {
-  curl -X POST -fsSL -u"${BITBUCKET_USER}:${BITBUCKET_TOKEN}" \
-      -H "Content-Type: application/json" \
-      -H "Accept: application/json" "$@"
-}
 
 # Need to get someone to let me test on a mac.
 # Macs can use pbcopy apparently, but they should just
@@ -45,25 +49,24 @@ cleanup() {
 action_help() {
   cat <<EOF
 
-Usage: bb-pr [$ACTION_LIST] [options]
-  help         : show this help
-  list         : list the PRs in this repo
-  squash-msg   : copy a reasonable message to the clipboard for merging a PR
-  squash-merge : merge the PR using the message from 'msg'
+Simple tooling that helps management of bitbucket pull requests from
+the commandline
 
-'squash-msg'
-'squash-merge'
+Usage: $(basename "$0") [$ACTION_LIST] [options]
+  help         : show this help
+  list         : list (open) PRs in this repo
+  squash-msg   : copy a reasonable message to the clipboard for merging a PR
+  squash-merge : merge the PR using the message from 'squash-msg'
+  approve      : approve a PR (though should you from the CLI?)
+  unapprove    : remove your approval
+
+'squash-msg' | 'squash-merge' | 'approve' | 'unapprove'
 Requires the PR number as its only parameter
 
-Requires you to have exported 2 environment variables:
-export BITBUCKET_USER=my_bitbucket_username
-export BITBUCKET_TOKEN=my_bitbucket_app_password
-
-c.f. https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/
-
-Uses:
-- jq : https://github.com/jqlang/jq
-- jf : https://github.com/sayanarijit/jf
+'list' can additionally filter by state
+  -s : the state (e.g. -s OPEN) OPEN|MERGED|DECLINED|SUPERSEDED
+       If you get it wrong, you'll get all the PRs which may take
+       longer than you want. Defaults to 'OPEN'
 
 EOF
   exit 1
@@ -74,18 +77,50 @@ action_list() {
     | { "id": (.id | tostring), "title": .title, "url": .links.html.href }
     | "\(.id)|\(.title)|\(.url)"
   '
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests"
-  curl_wrapper "$pull_request_url" | jq --raw-output "$jq_transform" | column -s "|" -t -N "ID,TITLE,URL"
+  local response
+  local next
+  local state="OPEN"
+
+  while getopts 's:' flag; do
+    case "${flag}" in
+    s) state="${OPTARG}";;
+    *) action_help;;
+    esac
+  done
+  state=$(echo "$state" | tr '[:lower:]' '[:upper:]')
+  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests?state=$state"
+
+  {
+    response=$(curl $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url")
+    echo "$response" | jq --raw-output "$jq_transform"
+    next=$(echo "$response" | jq --raw-output ".next")
+    until [ "$next" == "null" ]; do
+      response=$(curl $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$next")
+      echo "$response" | jq --raw-output "$jq_transform"
+      next=$(echo "$response" | jq --raw-output ".next")
+    done
+  } | sort | column -s "|" -t -N "ID,TITLE,URL"
 }
 
 
 action_approve() {
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$1/approve"
   local pr_number="$1"
+  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/approve"
   if [[ -z "$pr_number" ]]; then
     echo ">>> No PR"
-    exit
+    exit 1
   fi
+  curl -X POST $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" | jq --raw-output '"\(.state)"'
+}
+
+action_unapprove() {
+  local pr_number="$1"
+  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/approve"
+  if [[ -z "$pr_number" ]]; then
+    echo ">>> No PR"
+    exit 1
+  fi
+  curl -X DELETE $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url"
 }
 
 action_squash-msg() {
@@ -110,7 +145,7 @@ action_squash-merge() {
   local json_payload
   local pr_number="$1"
   local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/merge"
-  local response
+  local jq_transform='"\(.id)|\(.state)"'
   if [[ -z "$pr_number" ]]; then
     echo ">>> No PR"
     exit 1
@@ -124,8 +159,7 @@ action_squash-merge() {
   # probably want some tempfile action for a bit of --data @filename
   json_payload=$(jf '{%**q}' "type" "pullrequest" "message" "$squash_merge_msg" "merge_strategy" "squash")
   echo "$json_payload" > "$WORK_FILE"
-  echo "$json_payload"
-  curl_wrapper_post "$pull_request_url" "--data" "@$WORK_FILE" | jq .
+  curl -X POST $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "@$WORK_FILE" | jq --raw-output "$jq_transform" | column -s "|" -t -N "ID,STATE"
 }
 
 emit_squash_merge_msg() {
@@ -135,10 +169,10 @@ emit_squash_merge_msg() {
   local title
   local description
   local pr_number="$1"
-  local jq_approvers='.participants | .[] | select(.approved==true) | "Approved by \(.user.display_name)"'
+  local jq_approvers='.participants | .[] | select(.approved==true) | "Approved by: \(.user.display_name)"'
   local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
 
-  body=$(curl_wrapper "$pull_request_url")
+  body=$(curl $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url")
   description=$(echo "$body" | jq --raw-output ".description")
   title=$(echo "$body" | jq --raw-output ".title")
   # Is - is nicer than *


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Since there is an almost full REST API for bitbucket, we can replicate some features from `gh pr`

- `gh pr review --approve` -> `bb-pr approve XXX` along with its reversal `unapprove`
- `gh pr close` -> `bb-pr decline XXX`
- `bb-pr list` now supports pagination


## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add pagination support
- add approve
- add unapprove
- add decline
<!-- SQUASH_MERGE_END -->

## Testing

- tested list against 'infra2' which has 14 PRs open right now (so it issues 2x calls, since pagesize is 10)
  - tested `list -s declined` against infra2 but the column display is broken on 1080p screens because snyk does like an extra long title.
- tested approve/unapprove against PR 3 (docs/thinking->)
  - (it did happily allow me to approve & unapprove my own PR).

