### PR TITLE
feat: delete local branch on squash merge

### DIFF
--- a/bb-pr
+++ b/bb-pr
@@ -15,6 +15,9 @@ BITBUCKET_API_URL="https://api.bitbucket.org/2.0/repositories"
 GIT_REMOTE=$(git remote get-url origin | cut -f2 -d':') || true
 BITBUCKET_SLUG=${GIT_REMOTE%.git}
 GIT_REMOTE_BRANCH=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null | cut -f2- -d'/') || true
+GIT_LOCAL_WORKING_BRANCH=$(git branch --show-current) || true
+GIT_REMOTE_DEFAULT=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5) || true
+
 ACTION_LIST="help|list|squash-msg|squash-merge|approve|unapprove|decline"
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 
@@ -183,8 +186,16 @@ action_squash-merge() {
   local json_payload
   local pr_number="$1"
   local jq_transform='"\(.id)|\(.state)"'
+  local delete_local_branch=""
 
-  pr_number=$(get_pr_number "$pr_number")
+  # If there's no PR number then we assume we're branch based
+  # and since we are squash merging we try to behave like gh squash-merge
+  # and delete the local working branch
+  if [[ -z "$pr_number" ]]; then
+    pr_number=$(get_pr_number "")
+    delete_local_branch="true"
+  fi
+
   if [[ -z "$pr_number" ]]; then
     echo ">>> No PR"
     exit 1
@@ -202,6 +213,18 @@ action_squash-merge() {
   json_payload=$(jf '{%**q}' "type" "pullrequest" "message" "$squash_merge_msg" "merge_strategy" "squash")
   echo "$json_payload" >"$WORK_FILE"
   curl -X POST $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "@$WORK_FILE" | jq --raw-output "$jq_transform" | column -s "|" -t -N "ID,STATE"
+
+  if [[ -n "$delete_local_branch" ]]; then
+    git_switch_default
+  fi
+}
+
+git_switch_default() {
+  if [[ -n "$GIT_REMOTE_DEFAULT" && "$GIT_LOCAL_WORKING_BRANCH" ]]; then
+    git checkout "$GIT_REMOTE_DEFAULT"
+    git pull
+    git branch -D "$GIT_LOCAL_WORKING_BRANCH"
+  fi
 }
 
 emit_squash_merge_msg() {


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Just like gh-squash-merge we want to delete the local branch if that's what we are going to squash merge.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add function to switch back to 'main' and delete local branch
- branch deletion only happens if we never pass a pr number
<!-- SQUASH_MERGE_END -->

