### PR TITLE
feat: pipe discovery logging from git exec to /dev/null

### DIFF
--- a/bb-pr
+++ b/bb-pr
@@ -20,12 +20,12 @@ _giturl_to_base() {
 }
 
 BITBUCKET_API_URL="https://api.bitbucket.org/2.0/repositories"
-GIT_REMOTE=$(_giturl_to_base "$(git remote get-url origin)") || true
+GIT_REMOTE=$(_giturl_to_base "$(git remote get-url origin 2>/dev/null)") || true
 BITBUCKET_SLUG=${GIT_REMOTE%.git}
 GIT_REMOTE_BRANCH_FULL=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null) || true
 GIT_REMOTE_BRANCH=${GIT_REMOTE_BRANCH_FULL#*/}
-GIT_LOCAL_WORKING_BRANCH=$(git branch --show-current) || true
-GIT_REMOTE_DEFAULT=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5) || true
+GIT_LOCAL_WORKING_BRANCH=$(git branch --show-current 2>/dev/null) || true
+GIT_REMOTE_DEFAULT=$(git remote show origin 2>/dev/null| grep 'HEAD branch' | cut -d' ' -f5) || true
 
 ACTION_LIST="help|list|checkout|squash-msg|squash-merge|approve|unapprove|decline|close-branch"
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Because this happens if you're not in a git repo.

```shell
Ubuntu-22.04 ~
bsh ❯ bb-pr
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git

Tool that helps management of bitbucket pull requests from the commandline
```

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- pipe discovery logging from git exec to /dev/null
<!-- SQUASH_MERGE_END -->


## Testing

- If you're not in a git repo, then you shouldn't see the 'fatal' lines any longer
- should be no impact on other actions.
