### PR TITLE
feat: capture the error code from squash

### DIFF
--- a/bb-pr
+++ b/bb-pr
@@ -29,6 +29,7 @@ GIT_REMOTE_DEFAULT=$(git remote show origin 2>/dev/null| grep 'HEAD branch' | cu
 
 ACTION_LIST="help|list|checkout|squash-msg|squash-merge|approve|unapprove|decline|close-branch"
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
+SQUASH_MERGE_OUTPUT=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 
 CURL_AUTH="${BITBUCKET_USER}:${BITBUCKET_TOKEN}"
 CURL_HEADER_CTYPE="Content-Type: application/json"
@@ -56,6 +57,9 @@ clipboard_exe() {
 cleanup() {
   if [[ -n "${WORK_FILE:-}" ]]; then
     rm -f "$WORK_FILE"
+  fi
+  if [[ -n "${SQUASH_MERGE_OUTPUT:-}" ]]; then
+    rm -f "$SQUASH_MERGE_OUTPUT"
   fi
 }
 
@@ -220,6 +224,8 @@ action_squash-merge() {
   local squash_merge_msg
   local json_payload
   local jq_transform='"\(.id)|\(.state)"'
+  #shellcheck disable=SC2016
+  local failure_jq_transform='.error | .message as $message | .fields | to_entries[] | "\($message)|\(.value)"'
   local delete_local_branch=""
   local force_close_branch=""
 
@@ -269,10 +275,18 @@ action_squash-merge() {
     json_payload=$(jf '{%**q}' "type" "pullrequest" "message" "$squash_merge_msg" "merge_strategy" "squash")
   fi
   echo "$json_payload" >"$WORK_FILE"
-  curl -X POST $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "@$WORK_FILE" | jq --raw-output "$jq_transform" | column -s "|" -t -N "ID,STATE"
-
-  if [[ -n "$delete_local_branch" ]]; then
-    git_switch_default
+  http_code=$(curl -X POST -sSL --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "@$WORK_FILE" -o "$SQUASH_MERGE_OUTPUT" -w "%{http_code}")
+  if [[ "$http_code" -ge "400" ]];  then
+    #shellcheck disable=SC2002
+    cat "${SQUASH_MERGE_OUTPUT}" | jq --raw-output "$failure_jq_transform" | column -s "|" -t -N "ID,STATE"
+    echo Operation failed...
+    exit 1
+  else
+    #shellcheck disable=SC2002
+    cat "${SQUASH_MERGE_OUTPUT}" | jq --raw-output "$jq_transform" | column -s "|" -t -N "ID,STATE"
+    if [[ -n "$delete_local_branch" ]]; then
+      git_switch_default
+    fi
   fi
 }
 


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Resolves #23

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- capture the http_code from curl
- do a different JQ if the code !=200
<!-- SQUASH_MERGE_END -->

## Output

On an unsuccessful merge attempt it should show something like

```sh
bsh ❯ bb-pr squash-merge
ID                     STATE
2 failed merge checks  ["At least 1 approval","No in progress builds on last commit"]
Operation failed...
```