### PR TITLE
feat: add command bash completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,17 @@ export BITBUCKET_TOKEN=my_bitbucket_app_password
 
 - Check this repo out, and put it in the path.
 
+- For bash completion
+
+```shell
+eval "$(bb-pr completion)"
+```
+
 ```shell
 
 Tool that helps management of bitbucket pull requests from the commandline
 
-Usage: bb-pr [help|list|checkout|squash-msg|squash-merge|approve|unapprove|decline|close-branch] [options]
+Usage: bb-pr [help|list|checkout|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion] [options]
   help         : show this help
   list         : list (open) PRs in this repo
   checkout     : check out a pull request in git
@@ -54,6 +60,7 @@ Usage: bb-pr [help|list|checkout|squash-msg|squash-merge|approve|unapprove|decli
   unapprove    : remove your approval
   decline      : decline a PR
   close-branch : change the 'close_source_branch' field
+  completion   : returns command bash completion
 
 'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline' | 'close-branch'
 Without an argument, the pull request that belongs to the current branch

--- a/bb-pr
+++ b/bb-pr
@@ -25,9 +25,9 @@ BITBUCKET_SLUG=${GIT_REMOTE%.git}
 GIT_REMOTE_BRANCH_FULL=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null) || true
 GIT_REMOTE_BRANCH=${GIT_REMOTE_BRANCH_FULL#*/}
 GIT_LOCAL_WORKING_BRANCH=$(git branch --show-current 2>/dev/null) || true
-GIT_REMOTE_DEFAULT=$(git remote show origin 2>/dev/null| grep 'HEAD branch' | cut -d' ' -f5) || true
+GIT_REMOTE_DEFAULT=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d' ' -f5) || true
 
-ACTION_LIST="help|list|checkout|squash-msg|squash-merge|approve|unapprove|decline|close-branch"
+ACTION_LIST="help|list|checkout|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion"
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 SQUASH_MERGE_OUTPUT=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 
@@ -35,6 +35,8 @@ CURL_AUTH="${BITBUCKET_USER}:${BITBUCKET_TOKEN}"
 CURL_HEADER_CTYPE="Content-Type: application/json"
 CURL_HEADER_ACCEPT="Accept: application/json"
 CURL_FLAGS="-fsSL"
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
 trap cleanup 1 2 15
 
@@ -93,6 +95,7 @@ Usage: $(basename "$0") [$ACTION_LIST] [options]
   unapprove    : remove your approval
   decline      : decline a PR
   close-branch : change the 'close_source_branch' field
+  completion   : returns command bash completion
 
 'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline' | 'close-branch'
 Without an argument, the pull request that belongs to the current branch
@@ -276,7 +279,7 @@ action_squash-merge() {
   fi
   echo "$json_payload" >"$WORK_FILE"
   http_code=$(curl -X POST -sSL --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "@$WORK_FILE" -o "$SQUASH_MERGE_OUTPUT" -w "%{http_code}")
-  if [[ "$http_code" -ge "400" ]];  then
+  if [[ "$http_code" -ge "400" ]]; then
     #shellcheck disable=SC2002
     cat "${SQUASH_MERGE_OUTPUT}" | jq --raw-output "$failure_jq_transform" | column -s "|" -t -N "ID,STATE"
     echo Operation failed...
@@ -330,6 +333,10 @@ action_checkout() {
 
   git fetch --all
   git switch "$branch"
+}
+
+action_completion() {
+  cat "${SCRIPT_DIR}/completion.sh"
 }
 
 git_switch_default() {

--- a/completion.sh
+++ b/completion.sh
@@ -1,0 +1,130 @@
+# shellcheck shell=bash
+
+_bb-pr() {
+  local i cur prev opts cmd
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD - 1]}"
+  cmd=""
+  opts=""
+
+  for i in "${COMP_WORDS[@]}"; do
+    case "${cmd},${i}" in
+    ",$1")
+      cmd="bb-pr"
+      ;;
+    bb-pr,approve)
+      cmd="bb-pr__approve"
+      ;;
+    bb-pr,checkout)
+      cmd="bb-pr__checkout"
+      ;;
+    bb-pr,close-branch)
+      cmd="bb-pr__close-branch"
+      ;;
+    bb-pr,completion)
+      cmd="bb-pr__completion"
+      ;;
+    bb-pr,decline)
+      cmd="bb-pr__decline"
+      ;;
+    bb-pr,help)
+      cmd="bb-pr__help"
+      ;;
+    bb-pr,list)
+      cmd="bb-pr__list"
+      ;;
+    bb-pr,squash-merge)
+      cmd="bb-pr__squash-merge"
+      ;;
+    bb-pr,squash-msg)
+      cmd="bb-pr__squash-msg"
+      ;;
+    bb-pr,unapprove)
+      cmd="bb-pr__unapprove"
+      ;;
+    *) ;;
+    esac
+  done
+
+  case "${cmd}" in
+  bb-pr)
+    opts="approve checkout close-branch completion decline help list squash-merge squash-msg unapprove"
+    if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]]; then
+      mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
+      return 0
+    fi
+    case "${prev}" in
+    *)
+      COMPREPLY=()
+      ;;
+    esac
+    mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
+    return 0
+    ;;
+  bb-pr__close-branch)
+    opts="-c"
+    if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]]; then
+      mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
+      return 0
+    fi
+    case "${prev}" in
+    -c)
+      mapfile -t COMPREPLY < <(compgen -W "true false" -- "${cur}")
+      return 0
+      ;;
+    true | false)
+      mapfile -t COMPREPLY < <(compgen -- "${cur}")
+      return 0
+      ;;
+    *)
+      COMPREPLY=()
+      ;;
+    esac
+    mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
+    return 0
+    ;;
+  bb-pr__squash-merge)
+    opts="-D"
+    if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]]; then
+      mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
+      return 0
+    fi
+    case "${prev}" in
+    -D)
+      mapfile -t COMPREPLY < <(compgen -- "${cur}")
+      return 0
+      ;;
+    *)
+      COMPREPLY=()
+      ;;
+    esac
+    mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
+    return 0
+    ;;
+  bb-pr__list)
+    opts="-s"
+    if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]]; then
+      mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
+      return 0
+    fi
+    case "${prev}" in
+    -s)
+      mapfile -t COMPREPLY < <(compgen -W "OPEN MERGED DECLINED SUPERSEDED" -- "${cur}")
+      return 0
+      ;;
+    OPEN | MERGED | DECLINED | SUPERSEDED)
+      mapfile -t COMPREPLY < <(compgen -- "${cur}")
+      return 0
+      ;;
+    *)
+      COMPREPLY=()
+      ;;
+    esac
+    mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
+    return 0
+    ;;
+  esac
+}
+
+complete -F _bb-pr -o nosort -o bashdefault -o default bb-pr


### PR DESCRIPTION
# Motivation
Mostly because i'm lazy and can't spell.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add completion.sh 
- add new command to be used in bash_profile
<!-- SQUASH_MERGE_END -->

## Testing

```shell
eval "$(./bb-pr completion)"
bb-pr <TAB>
```

