### PR TITLE
fix: script directory follows symlinks

### DIFF
--- a/bb-pr
+++ b/bb-pr
@@ -36,7 +36,7 @@ CURL_HEADER_CTYPE="Content-Type: application/json"
 CURL_HEADER_ACCEPT="Accept: application/json"
 CURL_FLAGS="-fsSL"
 
-SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 trap cleanup 1 2 15
 


### PR DESCRIPTION
# Motivation
When using `bb-pr completion`

```shell
if [ -d "$HOME/.local/share/ubuntu-dpm/quotidian-ennui/bitbucket-pr" ]; then
  eval "$(bb-pr completion)"
fi
```

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- switch to using readlink to find checkout directory
<!-- SQUASH_MERGE_END -->

