### PR TITLE
feat: add alias for checkout as co

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ eval "$(bb-pr completion)"
 
 Tool that helps management of bitbucket pull requests from the commandline
 
-Usage: bb-pr [help|list|checkout|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion] [options]
+Usage: bb-pr [help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion] [options]
   help         : show this help
   list         : list (open) PRs in this repo
   checkout     : check out a pull request in git
+  co           : alias for checkout
   squash-msg   : copy a reasonable message to the clipboard for merging a PR
   squash-merge : merge the PR using the message from 'squash-msg'
   approve      : approve a PR (though should you from the CLI?)

--- a/bb-pr
+++ b/bb-pr
@@ -27,7 +27,7 @@ GIT_REMOTE_BRANCH=${GIT_REMOTE_BRANCH_FULL#*/}
 GIT_LOCAL_WORKING_BRANCH=$(git branch --show-current 2>/dev/null) || true
 GIT_REMOTE_DEFAULT=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d' ' -f5) || true
 
-ACTION_LIST="help|list|checkout|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion"
+ACTION_LIST="help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion"
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 SQUASH_MERGE_OUTPUT=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 
@@ -89,6 +89,7 @@ Usage: $(basename "$0") [$ACTION_LIST] [options]
   help         : show this help
   list         : list (open) PRs in this repo
   checkout     : check out a pull request in git
+  co           : alias for checkout
   squash-msg   : copy a reasonable message to the clipboard for merging a PR
   squash-merge : merge the PR using the message from 'squash-msg'
   approve      : approve a PR (though should you from the CLI?)
@@ -333,6 +334,10 @@ action_checkout() {
 
   git fetch --all
   git switch "$branch"
+}
+
+action_co() {
+  action_checkout "$@"
 }
 
 action_completion() {

--- a/completion.sh
+++ b/completion.sh
@@ -19,6 +19,9 @@ _bb-pr() {
     bb-pr,checkout)
       cmd="bb-pr__checkout"
       ;;
+    bb-pr,co)
+      cmd="bb-pr__checkout"
+      ;;
     bb-pr,close-branch)
       cmd="bb-pr__close-branch"
       ;;
@@ -49,7 +52,7 @@ _bb-pr() {
 
   case "${cmd}" in
   bb-pr)
-    opts="approve checkout close-branch completion decline help list squash-merge squash-msg unapprove"
+    opts="approve checkout close-branch co completion decline help list squash-merge squash-msg unapprove"
     if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]]; then
       mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
       return 0


### PR DESCRIPTION
# Motivation

Laziness and muscle memory to gh alias `co: pr checkout`

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->

- add co as an alias to checkout

<!-- SQUASH_MERGE_END -->

