### PR TITLE
feat: remove markdown links from description

### DIFF
--- a/bb-pr
+++ b/bb-pr
@@ -382,6 +382,8 @@ emit_squash_merge_msg() {
   squash_merge_details=${squash_merge_details##*($'\n')} # remove all leading newlines
   shopt -u extglob
 
+  squash_merge_details=$(echo "${squash_merge_details}" | sed -E 's/\[(.*?)\]\(.*?\)/\1/g') # remove markdown links
+
   if [[ -n "$squash_merge_details" ]]; then
     squash_merge_details="${squash_merge_details}"$'\n'$'\n' # add linebreaks to space out approver if set
   fi


### PR DESCRIPTION
# Motivation

Bitbucket is really helpful in adding links automatically, especially to Jira.

We don't want these links in commit message as it makes it hard to read in console.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add regex to remove markdown links from description
<!-- SQUASH_MERGE_END -->

## Testing

1. Add markdown link to `SQUASHMERGE` contents of existing PR
2. Run `..../bb-pr squash-msg <pr>`

