### PR TITLE
feat: add explicit conventional footer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ This is that and also replicates some functionality like `gh pr list`.
 <!-- SQUASHMERGESTART -->
 
 <!-- SQUASHMERGEEND -->
+
+<!-- put conventional commit footers here (see https://git-scm.com/docs/git-interpret-trailers for style) -->
+<!-- SQUASHMERGEFOOTERSTART -->
+Ref:
+<!-- SQUASHMERGEFOOTEREND -->
 ```
 
 > This isn't the same as the markers for `gh-squash-merge` because Atlassian doesn't _hide HTML comments_ and it escapes the underscores to avoid CommonMark highlighting. What's illuminating is that when you create a pull request you are subjected to the rich text editor, but edit it later gives you the markdown editor. Nevertheless, people will see your HTML comments, and there's nothing much that can be done to avoid that.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 I realise that I've been quite spoilt by the github cli.
 
-I'd like some way of replicating [gh-squash-merge](https://github.com/quotidian/gh-squash-merge) when playing around with bitbucket PRs.
+I'd like some way of replicating [gh-squash-merge](https://github.com/quotidian-ennui/gh-squash-merge) when playing around with bitbucket PRs.
 
 This is that and also replicates some functionality like `gh pr list`.
 
@@ -93,11 +93,11 @@ If we are on the branch 'fix/owasp'
 
 # Squash Merge the PR associated with 'fix/owasp' and close (delete) the source branch
 # The local branch 'fix/owasp' is deleted and you will end up on the 'main' branch
-bsh ❯ bb-pr squash-merge
+bsh ❯ bb-pr squash-merge -D
 
 # Squash Merge the PR associated with 'feat/owasp' according its PR settings
 # The local branch 'fix/owasp' is deleted and you will end up on the 'main' branch
-bsh ❯ bb-pr squash-merge -D
+bsh ❯ bb-pr squash-merge
 
 # Squash Merge the PR#5 leaving you on the 'feat/owasp'
 bsh ❯ bb-pr squash-merge 5

--- a/bb-pr
+++ b/bb-pr
@@ -382,6 +382,8 @@ emit_squash_merge_msg() {
   shopt -s extglob
   squash_merge_details=${squash_merge_details%%*($'\n')} # remove all trailing newlines
   squash_merge_details=${squash_merge_details##*($'\n')} # remove all leading newlines
+  squash_merge_footer=${squash_merge_footer%%*($'\n')} # remove all trailing newlines
+  squash_merge_footer=${squash_merge_footer##*($'\n')} # remove all leading newlines
   shopt -u extglob
 
   squash_merge_details=$(echo "${squash_merge_details}" | sed -E 's/\[(.*?)\]\(.*?\)/\1/g') # remove markdown links

--- a/bb-pr
+++ b/bb-pr
@@ -375,7 +375,9 @@ emit_squash_merge_msg() {
   squash_merge_details=$(echo "$description" | awk '/SQUASHMERGESTART/,/SQUASHMERGEEND/' |
     { grep -v "SQUASHMERGE" || test $? = 1; } |
     sed -E "s|^\*|-|")
-  pr_approvers=$(echo "$body" | jq --raw-output "$jq_approvers")
+  squash_merge_footer=$(echo "$description" | awk '/SQUASHMERGEFOOTERSTART/,/SQUASHMERGEFOOTEREND/' |
+    { grep -v "SQUASHMERGEFOOTER" || test $? = 1; } | tr -s '\n' '\n')
+  pr_approvers=$(echo "$body" | jq --raw-output "$jq_approvers" | tr -s '\n' '\n')
 
   shopt -s extglob
   squash_merge_details=${squash_merge_details%%*($'\n')} # remove all trailing newlines
@@ -383,14 +385,18 @@ emit_squash_merge_msg() {
   shopt -u extglob
 
   squash_merge_details=$(echo "${squash_merge_details}" | sed -E 's/\[(.*?)\]\(.*?\)/\1/g') # remove markdown links
+  squash_merge_footer=$(echo "${squash_merge_footer}" | sed -E 's/\[(.*?)\]\(.*?\)/\1/g') # remove markdown links
 
   if [[ -n "$squash_merge_details" ]]; then
     squash_merge_details="${squash_merge_details}"$'\n'$'\n' # add linebreaks to space out approver if set
   fi
+  if [[ -n "$squash_merge_footer" ]]; then
+    squash_merge_footer="${squash_merge_footer}"$'\n' # add linebreaks to space out approver if set
+  fi
 
   local squash_merge_msg="$title (pull request #$pr_number)
 
-$squash_merge_details$pr_approvers"
+$squash_merge_details$squash_merge_footer$pr_approvers"
 
   shopt -s extglob
   squash_merge_msg=${squash_merge_msg%%*($'\n')} # remove all trailing newlines


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
If you include conventional commit footers inside the SQUASHMERGE block, then they are separated by new lines so the squash merge msg comes out like this, which is a little lame. 
```
feat!: XXX

- a 
- b

BREAKING-CHANGE: Environment variable changes

Ref: BB-497

Ref: BB-77

Ref: BB-101

Approved-By: QE
```

That's just a consequence of "newlines being considered a paragraph break, which is really \n\n". We can't just squash 2+ newlines into a single one because then we don't get the required "new line between the body + footer..."

By introducing a SQUASHMERGEFOOTERSTART/END block we can use `tr -s` to squash multiple newlines into something meaningful...

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- added optional SQUASHMERGEFOOTER tag support
- use `tr` to squash multiple newlines
<!-- SQUASH_MERGE_END -->

## Result

The result should be (if you add in the correct blocks)

```
feat!: XXX

- a 
- b

BREAKING-CHANGE: Environment variable changes
Ref: BB-497
Ref: BB-77
Ref: BB-101
Approved-By: QE
```

Note that the first msg is parseable by something like `git cliff --context` so this is purely a visual remediation because we're not playing the same game that bitbucket plays and we want it to show up nicely when we do git log.