### PR TITLE
feat: add status command to show PR status

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ eval "$(bb-pr completion)"
 ```
 
 ```shell
+bsh ❯ bb-pr
 
 Tool that helps management of bitbucket pull requests from the commandline
 
-Usage: bb-pr [help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion] [options]
+Usage: bb-pr [help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion|status] [options]
   help         : show this help
   list         : list (open) PRs in this repo
   checkout     : check out a pull request in git
@@ -67,8 +68,11 @@ Usage: bb-pr [help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|de
   decline      : decline a PR
   close-branch : change the 'close_source_branch' field
   completion   : returns command bash completion
+  status       : shows the overall status of the requested PR
 
-'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline' | 'close-branch'
+'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline'
+'close-branch' | 'status'
+
 Without an argument, the pull request that belongs to the current branch
 is used.
 

--- a/bb-pr
+++ b/bb-pr
@@ -12,12 +12,17 @@
 set -eo pipefail
 
 declare -A emojiMap
+# build status
 emojiMap[SUCCESSFUL]="✅"
 emojiMap[FAILED]="⛔"
 emojiMap[INPROGRESS]="⌚"
-emojiMap[true]="👍"
+emojiMap[STOPPED]="❌"
+# participant.state (approval)
 emojiMap[approved]="👍"
 emojiMap[changes_requested]="✒️"
+emojiMap[null]="👀"
+# participant.approved (true|false)
+emojiMap[true]="👍"
 emojiMap[false]="👀"
 
 _giturl_to_base() {
@@ -398,7 +403,7 @@ __status_approvals() {
   local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
 
   approvalList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" \
-    | jq -r -c '.participants[] | select( .role == "REVIEWER") | { "name" : .user.display_name, "approved": .approved }')
+    | jq -r -c '.participants[] | select( .role == "REVIEWER") | { "name" : .user.display_name, "approved": .state}')
   if [[ -n "$approvalList" ]]; then
     while IFS= read -r line; do
       name=$(echo "$line" | jq -r '.name')

--- a/bb-pr
+++ b/bb-pr
@@ -228,6 +228,7 @@ action_status() {
   local pr_number=$1
   local name
   local status
+  local statusUrl
   local approvalList
   local buildStatusList
 
@@ -242,13 +243,14 @@ action_status() {
   approvalList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" \
     | jq -r -c '.participants[] | select( .role == "REVIEWER") | { "name" : .user.display_name, "approved": .approved }')
   buildStatusList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$build_status_url" \
-    | jq -r -c '.values[] | { "name" : .name, "state" : .state }')
+    | jq -r -c '.values[] | { "name" : .name, "state" : .state, "url": .url }')
   if [[ -n "$buildStatusList" ]]; then
     while IFS= read -r line; do
       name=$(echo "$line" | jq -r '.name')
       status=$(echo "$line" | jq -r '.state')
-      echo "$status|$name"
-    done <<<"$buildStatusList" | column -s"|" -t  -N "STATUS,JOB"
+      statusUrl=$(echo "$line" | jq -r '.url')
+      echo "$status|$name|$statusUrl"
+    done <<<"$buildStatusList" | column -s"|" -t  -N "STATUS,JOB,URL"
     echo ""
   fi
   if [[ -n "$approvalList" ]]; then
@@ -257,8 +259,9 @@ action_status() {
       status=$(echo "$line" | jq -r '.approved')
       echo "$name|$status"
     done <<<"$approvalList" | column -s"|" -t  -N "NAME,APPROVED"
+    echo ""
   else
-    echo ">>> No REVIEWERS on this PR ($pr_number)"
+    echo -e ">>> No REVIEWERS added to this PR ($pr_number)\n"
   fi
 }
 

--- a/bb-pr
+++ b/bb-pr
@@ -27,7 +27,7 @@ GIT_REMOTE_BRANCH=${GIT_REMOTE_BRANCH_FULL#*/}
 GIT_LOCAL_WORKING_BRANCH=$(git branch --show-current 2>/dev/null) || true
 GIT_REMOTE_DEFAULT=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d' ' -f5) || true
 
-ACTION_LIST="help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion"
+ACTION_LIST="help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion|status"
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 SQUASH_MERGE_OUTPUT=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 
@@ -223,6 +223,45 @@ action_squash-msg() {
   # shellcheck disable=SC2091
   echo "$squash_merge_msg" | eval "$(clipboard_exe)"
 }
+
+action_status() {
+  local pr_number=$1
+  local name
+  local status
+  local approvalList
+  local buildStatusList
+
+  pr_number=$(get_pr_number "$pr_number")
+  if [[ -z "$pr_number" ]]; then
+    echo ">>> No PR"
+    exit 1
+  fi
+  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
+  local build_status_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/statuses"
+
+  approvalList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" \
+    | jq -r -c '.participants[] | select( .role == "REVIEWER") | { "name" : .user.display_name, "approved": .approved }')
+  buildStatusList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$build_status_url" \
+    | jq -r -c '.values[] | { "name" : .name, "state" : .state }')
+  if [[ -n "$buildStatusList" ]]; then
+    while IFS= read -r line; do
+      name=$(echo "$line" | jq -r '.name')
+      status=$(echo "$line" | jq -r '.state')
+      echo "$status|$name"
+    done <<<"$buildStatusList" | column -s"|" -t  -N "STATUS,JOB"
+    echo ""
+  fi
+  if [[ -n "$approvalList" ]]; then
+    while IFS= read -r line; do
+      name=$(echo "$line" | jq -r '.name')
+      status=$(echo "$line" | jq -r '.approved')
+      echo "$name|$status"
+    done <<<"$approvalList" | column -s"|" -t  -N "NAME,APPROVED"
+  else
+    echo ">>> No REVIEWERS on this PR ($pr_number)"
+  fi
+}
+
 
 action_squash-merge() {
   local squash_merge_msg

--- a/bb-pr
+++ b/bb-pr
@@ -11,6 +11,15 @@
 
 set -eo pipefail
 
+declare -A emojiMap
+emojiMap[SUCCESSFUL]="✅"
+emojiMap[FAILED]="⛔"
+emojiMap[INPROGRESS]="⌚"
+emojiMap[true]="👍"
+emojiMap[approved]="👍"
+emojiMap[changes_requested]="✒️"
+emojiMap[false]="👀"
+
 _giturl_to_base() {
   local url=$1
   url=${url%%.git}
@@ -39,6 +48,15 @@ CURL_FLAGS="-fsSL"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 trap cleanup 1 2 15
+
+emoji() {
+  local key=$1
+  for mapEntry in "${!emojiMap[@]}"
+  do
+    [[ "$key" == "$mapEntry" ]] && echo "${emojiMap[${key}]}" && return
+  done
+  echo "$key"
+}
 
 # Need to get someone to let me test on a mac.
 # Macs can use pbcopy apparently, but they should just
@@ -97,8 +115,11 @@ Usage: $(basename "$0") [$ACTION_LIST] [options]
   decline      : decline a PR
   close-branch : change the 'close_source_branch' field
   completion   : returns command bash completion
+  status       : shows the overall status of the requested PR
 
-'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline' | 'close-branch'
+'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline'
+'close-branch' | 'status'
+
 Without an argument, the pull request that belongs to the current branch
 is used.
 
@@ -224,48 +245,6 @@ action_squash-msg() {
   echo "$squash_merge_msg" | eval "$(clipboard_exe)"
 }
 
-action_status() {
-  local pr_number=$1
-  local name
-  local status
-  local statusUrl
-  local approvalList
-  local buildStatusList
-
-  pr_number=$(get_pr_number "$pr_number")
-  if [[ -z "$pr_number" ]]; then
-    echo ">>> No PR"
-    exit 1
-  fi
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
-  local build_status_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/statuses"
-
-  approvalList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" \
-    | jq -r -c '.participants[] | select( .role == "REVIEWER") | { "name" : .user.display_name, "approved": .approved }')
-  buildStatusList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$build_status_url" \
-    | jq -r -c '.values[] | { "name" : .name, "state" : .state, "url": .url }')
-  if [[ -n "$buildStatusList" ]]; then
-    while IFS= read -r line; do
-      name=$(echo "$line" | jq -r '.name')
-      status=$(echo "$line" | jq -r '.state')
-      statusUrl=$(echo "$line" | jq -r '.url')
-      echo "$status|$name|$statusUrl"
-    done <<<"$buildStatusList" | column -s"|" -t  -N "STATUS,JOB,URL"
-    echo ""
-  fi
-  if [[ -n "$approvalList" ]]; then
-    while IFS= read -r line; do
-      name=$(echo "$line" | jq -r '.name')
-      status=$(echo "$line" | jq -r '.approved')
-      echo "$name|$status"
-    done <<<"$approvalList" | column -s"|" -t  -N "NAME,APPROVED"
-    echo ""
-  else
-    echo -e ">>> No REVIEWERS added to this PR ($pr_number)\n"
-  fi
-}
-
-
 action_squash-merge() {
   local squash_merge_msg
   local json_payload
@@ -390,6 +369,69 @@ action_co() {
 action_completion() {
   cat "${SCRIPT_DIR}/completion.sh"
 }
+
+# If we wanted to replicate the merge checks view in the UI we would
+# have to manually do https://jira.atlassian.com/browse/BCLOUD-22014
+# build-status we are doing
+action_status() {
+  local pr_number=$1
+  local name
+  local status
+  local statusUrl
+  local approvalList
+  local buildStatusList
+
+  pr_number=$(get_pr_number "$pr_number")
+  if [[ -z "$pr_number" ]]; then
+    echo ">>> No PR"
+    exit 1
+  fi
+  __status_builds "$pr_number"
+  __status_approvals "$pr_number"
+}
+
+__status_approvals() {
+  local pr_number=$1
+  local name
+  local status
+  local approvalList
+  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
+
+  approvalList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" \
+    | jq -r -c '.participants[] | select( .role == "REVIEWER") | { "name" : .user.display_name, "approved": .approved }')
+  if [[ -n "$approvalList" ]]; then
+    while IFS= read -r line; do
+      name=$(echo "$line" | jq -r '.name')
+      status=$(emoji "$(echo "$line" | jq -r '.approved')")
+      echo "$name|$status"
+    done <<<"$approvalList" | column -s"|" -t  -N "NAME,APPROVED"
+    echo ""
+  else
+    echo -e ">>> No REVIEWERS added to this PR ($pr_number)\n"
+  fi
+}
+
+__status_builds() {
+  local pr_number=$1
+  local name
+  local status
+  local statusUrl
+  local buildStatusList
+
+  local build_status_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/statuses"
+  buildStatusList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$build_status_url" \
+    | jq -r -c '.values[] | { "name" : .name, "state" : .state, "url": .url }')
+  if [[ -n "$buildStatusList" ]]; then
+    while IFS= read -r line; do
+      name=$(echo "$line" | jq -r '.name')
+      status=$(emoji "$(echo "$line" | jq -r '.state')")
+      statusUrl=$(echo "$line" | jq -r '.url')
+      echo "$status|$name|$statusUrl"
+    done <<<"$buildStatusList" | column -s"|" -t  -N "STATUS,JOB,URL"
+    echo ""
+  fi
+}
+
 
 git_switch_default() {
   if [[ -n "$GIT_REMOTE_DEFAULT" && "$GIT_LOCAL_WORKING_BRANCH" ]]; then

--- a/completion.sh
+++ b/completion.sh
@@ -43,6 +43,9 @@ _bb-pr() {
     bb-pr,squash-msg)
       cmd="bb-pr__squash-msg"
       ;;
+    bb-pr,status)
+      cmd="bb-pr__status"
+      ;;
     bb-pr,unapprove)
       cmd="bb-pr__unapprove"
       ;;
@@ -52,7 +55,7 @@ _bb-pr() {
 
   case "${cmd}" in
   bb-pr)
-    opts="approve checkout close-branch co completion decline help list squash-merge squash-msg unapprove"
+    opts="approve checkout close-branch co completion decline help list squash-merge squash-msg unapprove status"
     if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]]; then
       mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
       return 0


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Who wants to goto a webpage to get a status?

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add status action that uses pullrequests & pullrequests/status
- add status to completion script
<!-- SQUASH_MERGE_END -->

## Testing

- The nominal parameter is the PR number, but will happily discover the PR number from your branch.

```shell
bsh ❯ bb-pr status
STATUS  JOB               URL
✅      Pipeline #2145    https://bitbucket.org/...
✅      Pipeline #2146    https://bitbucket.org/...
⌚      Build #2          https://bitbucket.org/...

NAME            APPROVED
Pythagoras      👀
Maynard Keynes  👍
```
