### PR TITLE
refactor: add the squash-msg to status

### DIFF
--- a/bb-pr
+++ b/bb-pr
@@ -391,8 +391,11 @@ action_status() {
     echo ">>> No PR"
     exit 1
   fi
+  echo -e ">>> PR#$pr_number: $BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number\n"
   __status_builds "$pr_number"
   __status_approvals "$pr_number"
+  echo -e ">>> PR commit message:\n"
+  emit_squash_merge_msg "$pr_number"
 }
 
 __status_approvals() {
@@ -412,7 +415,7 @@ __status_approvals() {
     done <<<"$approvalList" | column -s"|" -t  -N "NAME,APPROVED"
     echo ""
   else
-    echo -e ">>> No REVIEWERS added to this PR ($pr_number)\n"
+    echo -e ">>> No REVIEWERS added to this PR\n"
   fi
 }
 


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Add some more information to the status 

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add the squash msg to the status output
<!-- SQUASH_MERGE_END -->

## Testing

No changes to flags, but if you run `bb-pr status` then you should get more information including a link to the actual PR in bitbucket (will be clickable in windows terminal etc).
