### PR TITLE
refactor: add a status_header function

### DIFF
--- a/bb-pr
+++ b/bb-pr
@@ -391,11 +391,20 @@ action_status() {
     echo ">>> No PR"
     exit 1
   fi
-  echo -e ">>> PR#$pr_number: $BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number\n"
+  __status_header "$pr_number"
   __status_builds "$pr_number"
   __status_approvals "$pr_number"
   echo -e ">>> PR commit message:\n"
   emit_squash_merge_msg "$pr_number"
+}
+
+__status_header() {
+  local pr_number=$1
+
+  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
+  body=$(curl $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url")
+  html_url=$(echo "$body" | jq -r '.links.html.href')
+  echo -e ">>> PR#$pr_number: $html_url\n"
 }
 
 __status_approvals() {


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Refactor to add a __status_header() function because the URL that is emitted != the URL that you can click on (since it is the REST API endpoint).

Switching to the status_header would also us to emit various other links like the approval/diff/commits links that are provided when you get the pr details via the API.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add a status_header function to derive the html_url of the PR.
<!-- SQUASH_MERGE_END -->

