### PR TITLE
feat: add env-var to disable emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Ref:
 - You will already have the standard tooling like `curl` | `tr` etc.
 - You need to define some environment variables to control your access to bitbucket (c.f. use [app-passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/))
   - Remember to give yourself write access to pull requests.
+- If you don't like emojis (or they don't display in your terminal): `export BB_PR_DISABLE_EMOJIS=true`
 
 ```bash
 export BITBUCKET_USER=my_bitbucket_username

--- a/bb-pr
+++ b/bb-pr
@@ -33,6 +33,7 @@ _giturl_to_base() {
   echo "$url"
 }
 
+EMOJIS_DISABLED=${BB_PR_DISABLE_EMOJIS:-false}
 BITBUCKET_API_URL="https://api.bitbucket.org/2.0/repositories"
 GIT_REMOTE=$(_giturl_to_base "$(git remote get-url origin 2>/dev/null)") || true
 BITBUCKET_SLUG=${GIT_REMOTE%.git}
@@ -40,7 +41,6 @@ GIT_REMOTE_BRANCH_FULL=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 
 GIT_REMOTE_BRANCH=${GIT_REMOTE_BRANCH_FULL#*/}
 GIT_LOCAL_WORKING_BRANCH=$(git branch --show-current 2>/dev/null) || true
 GIT_REMOTE_DEFAULT=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d' ' -f5) || true
-
 ACTION_LIST="help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion|status"
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 SQUASH_MERGE_OUTPUT=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
@@ -56,10 +56,12 @@ trap cleanup 1 2 15
 
 emoji() {
   local key=$1
-  for mapEntry in "${!emojiMap[@]}"
-  do
-    [[ "$key" == "$mapEntry" ]] && echo "${emojiMap[${key}]}" && return
-  done
+  if [[ "$EMOJIS_DISABLED" == "false" ]]; then
+    for mapEntry in "${!emojiMap[@]}"
+    do
+      [[ "$key" == "$mapEntry" ]] && echo "${emojiMap[${key}]}" && return
+    done
+  fi
   echo "$key"
 }
 


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Because sometimes people can't view emojis... 

- Cascadia Code shows emojis in the terminal but not all the starship git branch ones.
- nerd font will likely show emojis (I use firacode)
- IntelliJ's terminal doesn't by default (apparently)

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add "BB_PR_DISABLE_EMOJIS" env var
<!-- SQUASH_MERGE_END -->

## Testing

- Rather than "eyes" you'll see null on a fresh new PR because the status can be approved | changes_requested | null

```shell
export BB_PR_DISABLE_EMOJIS=true
bb-pr status
bsh ❯ bb-pr status
>>> PR#22: https://bitbucket.org/.../nnn

NAME            APPROVED
Pythagoras      null
Euler           null
Archimedes      null
```
