### PR TITLE
feat: add bb-pr whoami command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ export BITBUCKET_TOKEN=my_bitbucket_app_password
 eval "$(bb-pr completion)"
 ```
 
-```shell
+```console
 bsh ❯ bb-pr
 
 Tool that helps management of bitbucket pull requests from the commandline
 
-Usage: bb-pr [help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion|status] [options]
+Usage: bb-pr [help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion|status|whoami] [options]
   help         : show this help
   list         : list (open) PRs in this repo
   checkout     : check out a pull request in git
@@ -70,12 +70,13 @@ Usage: bb-pr [help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|de
   close-branch : change the 'close_source_branch' field
   completion   : returns command bash completion
   status       : shows the overall status of the requested PR
+  whoami       : shows some information about your current user
+                 requires 'account read' scope
 
 'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline'
 'close-branch' | 'status'
 
-Without an argument, the pull request that belongs to the current branch
-is used.
+Without an argument, the pull request that belongs to the current branch is used.
 
 Arguments
   <PR> The PR number to operate on.

--- a/bb-pr
+++ b/bb-pr
@@ -34,14 +34,15 @@ _giturl_to_base() {
 }
 
 EMOJIS_DISABLED=${BB_PR_DISABLE_EMOJIS:-false}
-BITBUCKET_API_URL="https://api.bitbucket.org/2.0/repositories"
+BITBUCKET_API_BASE="https://api.bitbucket.org/2.0"
+BITBUCKET_REPO_API_URL="$BITBUCKET_API_BASE/repositories"
 GIT_REMOTE=$(_giturl_to_base "$(git remote get-url origin 2>/dev/null)") || true
 BITBUCKET_SLUG=${GIT_REMOTE%.git}
 GIT_REMOTE_BRANCH_FULL=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null) || true
 GIT_REMOTE_BRANCH=${GIT_REMOTE_BRANCH_FULL#*/}
 GIT_LOCAL_WORKING_BRANCH=$(git branch --show-current 2>/dev/null) || true
 GIT_REMOTE_DEFAULT=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d' ' -f5) || true
-ACTION_LIST="help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion|status"
+ACTION_LIST="help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion|status|whoami"
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 SQUASH_MERGE_OUTPUT=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 
@@ -95,7 +96,7 @@ get_pr_number() {
   if [[ -z "$pr_number" && -n "${GIT_REMOTE_BRANCH}" ]]; then
     query=$(printf "source.branch.name=\"%s\" AND state=\"OPEN\"" "${GIT_REMOTE_BRANCH}")
     query_uri=$(printf %s "${query}" | jq -sRr @uri)
-    local pull_request_query_url="${BITBUCKET_API_URL}/${BITBUCKET_SLUG}/pullrequests?q=${query_uri}"
+    local pull_request_query_url="${BITBUCKET_REPO_API_URL}/${BITBUCKET_SLUG}/pullrequests?q=${query_uri}"
     pr_number=$(curl $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "${pull_request_query_url}" | jq .values[0].id)
     if [ "$pr_number" != "null" ]; then
       echo "$pr_number"
@@ -123,12 +124,13 @@ Usage: $(basename "$0") [$ACTION_LIST] [options]
   close-branch : change the 'close_source_branch' field
   completion   : returns command bash completion
   status       : shows the overall status of the requested PR
+  whoami       : shows some information about your current user
+                 requires 'account read' scope
 
 'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline'
 'close-branch' | 'status'
 
-Without an argument, the pull request that belongs to the current branch
-is used.
+Without an argument, the pull request that belongs to the current branch is used.
 
 Arguments
   <PR> The PR number to operate on.
@@ -164,7 +166,7 @@ bsh ❯ bb-pr squash-merge 5
 bsh ❯ bb-pr squash-merge -D 5
 
 EOF
-  exit 1
+  exit 2
 }
 
 action_list() {
@@ -183,7 +185,7 @@ action_list() {
     esac
   done
   state=$(echo "$state" | tr '[:lower:]' '[:upper:]')
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests?state=$state"
+  local pull_request_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests?state=$state"
 
   {
     next="$pull_request_url"
@@ -203,7 +205,7 @@ action_decline() {
     exit 1
   fi
 
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/decline"
+  local pull_request_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/decline"
 
   curl -X POST $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" | jq --raw-output '"\(.state)"'
 }
@@ -216,7 +218,7 @@ action_approve() {
     exit 1
   fi
 
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/approve"
+  local pull_request_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/approve"
 
   curl -X POST $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" | jq --raw-output '"\(.state)"'
 }
@@ -229,7 +231,7 @@ action_unapprove() {
     exit 1
   fi
 
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/approve"
+  local pull_request_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/approve"
 
   curl -X DELETE $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url"
 }
@@ -291,7 +293,7 @@ action_squash-merge() {
     exit 1
   fi
 
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/merge"
+  local pull_request_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/merge"
 
   squash_merge_msg=$(emit_squash_merge_msg "$pr_number")
 
@@ -346,7 +348,7 @@ action_close-branch() {
   done
   local pr_number="$1"
   pr_number=$(get_pr_number "$pr_number")
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
+  local pull_request_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
   json_payload=$(jf '{%**q}' "close_source_branch" "$close_branch")
   echo "$json_payload" >"$WORK_FILE"
   curl -X PUT $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "@$WORK_FILE" | jq --raw-output '"close_source_branch now \(.close_source_branch)"'
@@ -360,7 +362,7 @@ action_checkout() {
     exit 1
   fi
 
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
+  local pull_request_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
   body=$(curl $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url")
 
   branch=$(echo "$body" | jq --raw-output ".source.branch.name")
@@ -400,10 +402,14 @@ action_status() {
   emit_squash_merge_msg "$pr_number"
 }
 
+action_whoami() {
+  curl $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$BITBUCKET_API_BASE/user" | jq 'del (.links)'
+}
+
 __status_header() {
   local pr_number=$1
 
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
+  local pull_request_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
   body=$(curl $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url")
   html_url=$(echo "$body" | jq -r '.links.html.href')
   echo -e ">>> PR#$pr_number: $html_url\n"
@@ -414,7 +420,7 @@ __status_approvals() {
   local name
   local status
   local approvalList
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
+  local pull_request_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
 
   approvalList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" \
     | jq -r -c '.participants[] | select( .role == "REVIEWER") | { "name" : .user.display_name, "approved": .state}')
@@ -437,7 +443,7 @@ __status_builds() {
   local statusUrl
   local buildStatusList
 
-  local build_status_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/statuses"
+  local build_status_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number/statuses"
   buildStatusList=$(curl -X GET $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$build_status_url" \
     | jq -r -c '.values[] | { "name" : .name, "state" : .state, "url": .url }')
   if [[ -n "$buildStatusList" ]]; then
@@ -469,7 +475,7 @@ emit_squash_merge_msg() {
   local description
   local pr_number="$1"
   local jq_approvers='.participants | .[] | select(.approved==true) | "Approved-By: \(.user.display_name)"'
-  local pull_request_url="$BITBUCKET_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
+  local pull_request_url="$BITBUCKET_REPO_API_URL/$BITBUCKET_SLUG/pullrequests/$pr_number"
 
   body=$(curl $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url")
   description=$(echo "$body" | jq --raw-output '.description | gsub("\\\\"; "")')


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Supports #65 by letting you see your uuid.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add whoami command
<!-- SQUASH_MERGE_END -->

## Testing

APP TOKEN is required to contain the read-account scope; so it's probably now just realistic to have a `all-read-pr-write` token...
