### PR TITLE
fix: protect against missing branch

### DIFF
--- a/bb-pr
+++ b/bb-pr
@@ -463,10 +463,10 @@ __status_header() {
   body=$(curl $CURL_FLAGS --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url")
   html_url=$(echo "$body" | jq -r '.links.html.href')
   branch_name=$(echo "$body" | jq -r '.source.branch.name')
-  behind=$(git rev-list --left-right --count origin/"$GIT_REMOTE_DEFAULT"...origin/"$branch_name" | cut -f1)
+  behind=$(git rev-list --left-right --count origin/"$GIT_REMOTE_DEFAULT"...origin/"$branch_name" 2>/dev/null | cut -f1 || true)
 
   echo -e ">>> PR#$pr_number: $html_url\n"
-  if [[ "$behind" -gt "0" ]]; then
+  if [[ "$behind" != "" && "$behind" -gt "0" ]]; then
     echo -e ">>> This PR is behind $GIT_REMOTE_DEFAULT by $behind commits; potentially unmergeable\n"
   fi
 }


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
#87 introduced a bug whereby if the origin/branch does not exist locally then git fails, which means you never see the status

You might not have the branch pulled because

- you're out of date (you want to see the status on something that you've never worked on)
- you're looking at the status of a historical PR that has already squash-merged and deleted the branch

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add || true when doing git rev-list
<!-- SQUASH_MERGE_END -->

## Testing

- Select a PR that's already been merged, and the corresponding branch has been deleted.
- `bb-pr status NNN` should still work, but not tell you about how many commits you are behind.
