### PR TITLE
refactor: deprecate squash-msg for message

### DIFF
--- a/bb-pr
+++ b/bb-pr
@@ -43,7 +43,9 @@ GIT_REMOTE_BRANCH_FULL=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 
 GIT_REMOTE_BRANCH=${GIT_REMOTE_BRANCH_FULL#*/}
 GIT_LOCAL_WORKING_BRANCH=$(git branch --show-current 2>/dev/null) || true
 GIT_REMOTE_DEFAULT=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d' ' -f5) || true
-ACTION_LIST="help|list|checkout|co|squash-msg|squash-merge|approve|unapprove|decline|close-branch|completion|status|whoami|ready|draft"
+PREFERRED_ACTIONS_LIST="help|list|checkout|co|message|squash-merge|approve|unapprove|decline|close-branch|completion|status|whoami|ready|draft"
+ACTION_LIST="$PREFERRED_ACTIONS_LIST|squash-msg"
+
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 SQUASH_MERGE_OUTPUT=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 
@@ -112,12 +114,15 @@ action_help() {
 
 Tool that helps management of bitbucket pull requests from the commandline
 
-Usage: $(basename "$0") [$ACTION_LIST] [options]
+Usage: $(basename "$0") [$PREFERRED_ACTIONS_LIST] [options]
   help         : show this help
   list         : list (open) PRs in this repo
   checkout     : check out a pull request in git
   co           : alias for checkout
-  squash-msg   : copy a reasonable message to the clipboard for merging a PR
+  message      : copy a reasonable message to the clipboard for merging a PR
+                 (squash-msg still exists for backwards compatibility but
+                 will be removed real soon now to avoid conflicts with completion
+                 convenience)
   squash-merge : merge the PR using the message from 'squash-msg'
   approve      : approve a PR (though should you from the CLI?)
   unapprove    : remove your approval
@@ -135,8 +140,8 @@ Usage: $(basename "$0") [$ACTION_LIST] [options]
                  - This will change the PR from draft to ready
   draft        : Remove all the reviewers and mark as draft
 
-'squash-msg' | 'squash-merge' | 'approve' | 'unapprove' | 'decline'
-'close-branch' | 'status' | 'ready'
+'message' | 'squash-merge' | 'approve' | 'unapprove' | 'decline'
+'close-branch' | 'status' | 'ready' | 'draft'
 
 Without an argument, the pull request that belongs to the current branch is used.
 
@@ -245,6 +250,11 @@ action_unapprove() {
 }
 
 action_squash-msg() {
+  echo -e "\n>>> use of deprecated 'squash-msg', try 'message' instead"
+  action_message "$@"
+}
+
+action_message() {
   local pr_number=$1
   local squash_merge_msg
 
@@ -260,6 +270,7 @@ action_squash-msg() {
   echo "is now in your clipboard"
   # shellcheck disable=SC2091
   echo "$squash_merge_msg" | eval "$(clipboard_exe)"
+
 }
 
 action_squash-merge() {

--- a/completion.sh
+++ b/completion.sh
@@ -40,8 +40,8 @@ _bb-pr() {
     bb-pr,squash-merge)
       cmd="bb-pr__squash-merge"
       ;;
-    bb-pr,squash-msg)
-      cmd="bb-pr__squash-msg"
+    bb-pr,message)
+      cmd="bb-pr__message"
       ;;
     bb-pr,status)
       cmd="bb-pr__status"
@@ -64,7 +64,7 @@ _bb-pr() {
 
   case "${cmd}" in
   bb-pr)
-    opts="approve checkout close-branch co completion decline help list ready squash-merge squash-msg status unapprove whoami draft"
+    opts="approve checkout close-branch co completion decline help list ready squash-merge message status unapprove whoami draft"
     if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]]; then
       mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
       return 0


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

`squash-msg` kinda breaks completion (since you have to type so much), so rename squash-msg into something more autocomplete friendly

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- switch squash-msg for message in completion script
- make squash-msg an alias for message (like co is).
<!-- SQUASH_MERGE_END -->

## Testing

- `bb-pr squash-msg 581` -> still works but emits an extra log message
- `bb-pr message 581` -> works as you'd expect
- `bb-pr m<tab>` -> auto-completes.
