### PR TITLE
feat: enable fzf wherever PR number is required

### DIFF
--- a/includes/bb_checkout
+++ b/includes/bb_checkout
@@ -3,20 +3,8 @@
 action_checkout() {
   local pr_number=${1:-}
   if [[ -z "$pr_number" ]]; then
-    pr_list=$(__emit_pr_list -q)
-    if [[ -z "$pr_list" ]]; then
-        >&2 echo "bb-pr checkout: no PRS found, nothing to do."
-        exit 1
-    fi
-    if type -p fzf > /dev/null; then
-        selected_pr=$(fzf --height ~100% --prompt="Select PR > " <<< "${pr_list}")
-    else
-        >&2 echo "bb-pr checkout: need 'fzf' for fuzzy search if no pr_number"
-        exit 1
-    fi
-    pr_number=$(cut -d'|' -f1 <<< "${selected_pr}")
+    pr_number=$(__pr_from_fzf)
   fi
-
   if [[ -z "$pr_number" ]]; then
     echo ">>> No PR"
     exit 1

--- a/includes/common
+++ b/includes/common
@@ -80,17 +80,12 @@ cleanup() {
 
 get_pr_number() {
   local pr_number="$1"
-  if [[ -z "$pr_number" && -n "${GIT_REMOTE_BRANCH}" ]]; then
-    query=$(printf "source.branch.name=\"%s\" AND state=\"OPEN\"" "${GIT_REMOTE_BRANCH}")
-    query_uri=$(printf %s "${query}" | jq -sRr @uri)
-    local pull_request_query_url="${BITBUCKET_REPO_API_URL}/${BITBUCKET_SLUG}/pullrequests?q=${query_uri}"
-    pr_number=$(curl "${CURL_FLAGS[@]}" --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "${pull_request_query_url}" | jq .values[0].id)
-    if [ "$pr_number" != "null" ]; then
-      echo "$pr_number"
-    fi
-  else
-    echo "$pr_number"
+
+  pr_number=$(__pr_from_branch "$pr_number")
+  if [[ -z "$pr_number" ]]; then
+    pr_number=$(__pr_from_fzf)
   fi
+  echo "$pr_number"
 }
 
 
@@ -194,6 +189,37 @@ __emit_pr_list() {
       next=$(echo "$response" | jq --raw-output ".next" || true)
     done
   }
+}
+
+__pr_from_fzf() {
+  local pr_number=""
+
+  if type -p fzf > /dev/null; then
+    pr_list=$(__emit_pr_list -q)
+    if [[ -z "$pr_list" ]]; then
+        >&2 echo "bb-pr: no PRS found, nothing to do."
+        exit 1
+    fi
+    selected_pr=$(fzf --height ~100% --prompt="Select PR > " <<< "${pr_list}")
+    pr_number=$(cut -d'|' -f1 <<< "${selected_pr}")
+  fi
+  echo "$pr_number"
+}
+
+__pr_from_branch() {
+  local pr_number=$1
+
+  if [[ -z "$pr_number" && -n "${GIT_REMOTE_BRANCH}" ]]; then
+    query=$(printf "source.branch.name=\"%s\" AND state=\"OPEN\"" "${GIT_REMOTE_BRANCH}")
+    query_uri=$(printf %s "${query}" | jq -sRr @uri)
+    local pull_request_query_url="${BITBUCKET_REPO_API_URL}/${BITBUCKET_SLUG}/pullrequests?q=${query_uri}"
+    pr_number=$(curl "${CURL_FLAGS[@]}" --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "${pull_request_query_url}" | jq .values[0].id)
+    if [ "$pr_number" != "null" ]; then
+      echo "$pr_number"
+    fi
+  else
+    echo "$pr_number"
+  fi
 }
 
 trap cleanup 1 2 15


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

fzf is for life, not just for christmas?

Wherever we have an activity where we require a pr number to checkout, then we can delegate that to `fzf` if we cannot work out what it is that we want.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- refactor fzf use out of bb_checkout into common
- refactor get_pr_number to use fzf if autodetect fails
<!-- SQUASH_MERGE_END -->

## Testing

> Of course, it requires fzf to be on the path; if it is not on the path, then no fzf magic happens and behaviour should be as expected (i.e. `bb-pr status` will fail on the main branch)

### On the main branch or branch with no PR

- `bb-pr co` will bring up all the PRs
- `bb-pr status` will bring up all the PRs 
- ... and so on and so forth

### On an existing branch that has a PR

- `bb-pr status` will just bring up the status
- `bb-pr draft` will make that PR draft
