### PR TITLE
refactor: add rest_with_callback helper function

### DIFF
--- a/includes/bb_draft
+++ b/includes/bb_draft
@@ -15,17 +15,17 @@ action_draft() {
   "draft": true,
   "reviewers": []
 }'
-  http_code=$(curl -X PUT -sSL --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "$pr_body" -o "$SQUASH_MERGE_OUTPUT" -w "%{http_code}")
-  if [[ "$http_code" -ge "400" ]]; then
-    errorMsg=$(cat "$SQUASH_MERGE_OUTPUT" | jq --raw-output '.error.message')
-    if [[ "$errorMsg" != "" ]]; then
-      echo -e "$errorMsg"
-    else
-      cat "${SQUASH_MERGE_OUTPUT}"
-    fi
-    echo Operation failed...
-    exit 1
-  else
-    cat "$SQUASH_MERGE_OUTPUT" | jq --raw-output '"Draft Mode: \(.draft)"'
-  fi
+  __bb_rest_with_callback \
+    "__draft_success_output" \
+    "__draft_failure_output" \
+    "" \
+    -X PUT -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "$pr_body"
+}
+
+__draft_success_output() {
+  jq --raw-output '"Draft Mode: \(.draft)"'
+}
+
+__draft_failure_output() {
+  jq --raw-output '.error.message'
 }

--- a/includes/bb_ready
+++ b/includes/bb_ready
@@ -13,7 +13,6 @@ walk (if type == "object" and .uuid == $uuid then empty else . end) |
   local reviewers_file
   local pr_body
   local login_uuid
-  local http_code
 
   pr_number=$(get_pr_number "$pr_number")
   if [[ -z "$pr_number" ]]; then
@@ -28,18 +27,17 @@ walk (if type == "object" and .uuid == $uuid then empty else . end) |
   fi
   login_uuid=$(curl "${CURL_FLAGS[@]}" --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$pull_request_url" | jq --raw-output '.author.uuid')
   pr_body="$(cat "$reviewers_file" | yq -p yaml -o json | jq -r --arg uuid "$login_uuid" "$jq_reviewers")"
-  http_code=$(curl -X PUT -sSL --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "$pr_body" -o "$SQUASH_MERGE_OUTPUT" -w "%{http_code}")
-  if [[ "$http_code" -ge "400" ]]; then
-    errorMsg=$(cat "$SQUASH_MERGE_OUTPUT" | jq --raw-output '.error.message')
-    if [[ "$errorMsg" != "" ]]; then
-      echo -e "$errorMsg"
-    else
-      cat "${SQUASH_MERGE_OUTPUT}"
-    fi
-    echo Operation failed...
-    exit 1
-  else
-    cat "$SQUASH_MERGE_OUTPUT" | jq --raw-output '"Added reviewer: \(.reviewers | .[] | .display_name)"'
-  fi
+  __bb_rest_with_callback \
+    "__ready_success_output" \
+    "__ready_failure_output" \
+    "" \
+    -X PUT -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "$pr_body"
+}
 
+__ready_success_output() {
+  jq --raw-output '"Added reviewer: \(.reviewers | .[] | .display_name)"'
+}
+
+__ready_failure_output() {
+  jq --raw-output '.error.message'
 }

--- a/includes/bb_squash-merge
+++ b/includes/bb_squash-merge
@@ -3,9 +3,6 @@
 action_squash-merge() {
   local squash_merge_msg
   local json_payload
-  local jq_transform='"\(.id)|\(.state)"'
-  #shellcheck disable=SC2016
-  local failure_jq_transform='.error | .message as $message | .fields | to_entries[] | "\($message)|\(.value)"'
   local delete_local_branch=""
   local force_close_branch=""
 
@@ -55,22 +52,27 @@ action_squash-merge() {
     json_payload=$(jf '{%**q}' "type" "pullrequest" "message" "$squash_merge_msg" "merge_strategy" "squash")
   fi
   echo "$json_payload" >"$WORK_FILE"
-  http_code=$(curl -X POST -sSL --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "@$WORK_FILE" -o "$SQUASH_MERGE_OUTPUT" -w "%{http_code}")
-  if [[ "$http_code" -ge "400" ]]; then
-    #shellcheck disable=SC2002
-    errorMsg=$(cat "${SQUASH_MERGE_OUTPUT}" | jq --raw-output "$failure_jq_transform" | column -s "|" -t -N "ID,STATE")
-    if [[ "$errorMsg" != "" ]]; then
-      echo -e "$errorMsg"
-    else
-      cat "${SQUASH_MERGE_OUTPUT}"
-    fi
-    echo Operation failed...
-    exit 1
-  else
-    #shellcheck disable=SC2002
-    cat "${SQUASH_MERGE_OUTPUT}" | jq --raw-output "$jq_transform" | column -s "|" -t -N "ID,STATE"
-    if [[ -n "$delete_local_branch" ]]; then
-      git_switch_default
-    fi
+  __bb_rest_with_callback "__squash_merge_success_output" \
+    "__squash_merge_failure_output" \
+    "__squash_merge_success_callback $delete_local_branch" \
+    -X POST -H "$CURL_HEADER_CTYPE" "$pull_request_url" "--data" "@$WORK_FILE"
+}
+
+__squash_merge_success_output() {
+  local jq_transform='"\(.id)|\(.state)"'
+  jq --raw-output "$jq_transform" | column -s "|" -t -N "ID,STATE"
+}
+
+__squash_merge_failure_output() {
+  #shellcheck disable=SC2016
+  local failure_jq_transform='.error | .message as $message | .fields | to_entries[] | "\($message)|\(.value)"'
+  jq --raw-output "$failure_jq_transform" | column -s "|" -t -N "ID,STATE"
+}
+
+__squash_merge_success_callback() {
+  local delete_local_branch="$1"
+  if [[ "$delete_local_branch" == "true" ]]; then
+    echo "ℹ️ Switching local branch to default branch"
+    git_switch_default
   fi
 }

--- a/includes/common
+++ b/includes/common
@@ -174,8 +174,30 @@ __bb_rest_invoke() {
   curl "${CURL_FLAGS[@]}" --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$@"
 }
 
+# __bb_rest_with_callback
+#
+# Performs a Bitbucket REST API request using curl, handles HTTP errors, and processes the response
+# via user-supplied success and failure callback functions.
+#
+# Arguments:
+#   $1 - The command to handle successful responses (successOutput)
+#   $2 - The command to handle error responses (failureOutput)
+#   $3 - The command to call after a successful response (successCallback), or "" for none
+#   $@ - Remaining arguments are passed directly to curl (e.g., -X PUT, URL, --data, etc.)
+#
+# Behaviour:
+#   - Executes curl with the provided arguments, writing output to $CURL_BB_OUTPUT and capturing HTTP code.
+#   - If HTTP code >= 400, invokes the failureOutput function with the response, prints its output,
+#     or prints the raw response if no message is found, then exits with error.
+#   - If HTTP code < 400, invokes the successOutput function with the response and, if provided,
+#     calls the successCallback function.
+#
+# Usage Example:
+#   __bb_rest_with_callback my_success_message my_failure_failure "if_successful_action"
+#      -X PUT -H "$CURL_HEADER_CTYPE" "$url" --data "$body"
 __bb_rest_with_callback() {
   local http_code
+  local errorMsg
   local successOutput="$1"
   local failureOutput="$2"
   local successCallback="$3"

--- a/includes/common
+++ b/includes/common
@@ -40,7 +40,7 @@ GIT_LOCAL_WORKING_BRANCH=$(git branch --show-current 2>/dev/null) || true
 GIT_REMOTE_DEFAULT=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d' ' -f5) || true
 
 WORK_FILE=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
-SQUASH_MERGE_OUTPUT=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
+CURL_BB_OUTPUT=$(mktemp --tmpdir bb-pr-squash-merge.XXXXXX)
 
 CURL_AUTH="${BITBUCKET_USER}:${BITBUCKET_TOKEN}"
 CURL_HEADER_CTYPE="Content-Type: application/json"
@@ -90,8 +90,8 @@ cleanup() {
   if [[ -n "${WORK_FILE:-}" ]]; then
     rm -f "$WORK_FILE"
   fi
-  if [[ -n "${SQUASH_MERGE_OUTPUT:-}" ]]; then
-    rm -f "$SQUASH_MERGE_OUTPUT"
+  if [[ -n "${CURL_BB_OUTPUT:-}" ]]; then
+    rm -f "$CURL_BB_OUTPUT"
   fi
 }
 
@@ -170,16 +170,35 @@ __emit_squash_merge_msg() {
   __emit_squash_merge_msg_from_body "$body"
 }
 
-__curl_only_http_code() {
-  local -n v="$1"
-  local url="$3"
-  {
-    v="$(curl "${CURL_FLAGS[@]}" --user "$CURL_AUTH" "$url" -w "%{stderr}%{http_code}" 2>&1 1>&3 3>&-)"
-  } 3>/dev/null
-}
-
 __bb_rest_invoke() {
   curl "${CURL_FLAGS[@]}" --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" "$@"
+}
+
+__bb_rest_with_callback() {
+  local http_code
+  local successOutput="$1"
+  local failureOutput="$2"
+  local successCallback="$3"
+  shift 3
+
+  http_code=$(curl -sSL --user "$CURL_AUTH" -H "$CURL_HEADER_ACCEPT" -o "$CURL_BB_OUTPUT" -w "%{http_code}" "$@")
+  if [[ "$http_code" -ge "400" ]]; then
+    #shellcheck disable=SC2002
+    errorMsg=$(cat "${CURL_BB_OUTPUT}" | ($failureOutput))
+    if [[ "$errorMsg" != "" ]]; then
+      echo -e "$errorMsg"
+    else
+      cat "${CURL_BB_OUTPUT}"
+    fi
+    echo Operation failed...
+    exit 1
+  else
+    #shellcheck disable=SC2002
+    cat "${CURL_BB_OUTPUT}" | ($successOutput)
+    if [[ -n "$successCallback" ]]; then
+      ($successCallback)
+    fi
+  fi
 }
 
 __emit_pr_list() {


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

It's because this form is used in 3 places, and they're the _same_ and yet _different_.

AI couldn't seem to refactor it so I did by using function callbacks because bash supports it.

```
http_code=$(curl something something -o "$SQUASH_MERGE_OUTPUT" -w "%{http_code}")
  if [[ "$http_code" -ge "400" ]]; then
    # emit a failure message
    echo Operation failed...
    exit 1
  else
    # emit a success message
    # do something on success.
  fi
```

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- Added a a __bb_rest_with_callback function
- switch bb_ready to use __bb_rest_with_callback
- switch bb_squash_merge to use __bb_rest_with_callback
- switch bb_draft to use __bb_rest_with_callback
<!-- SQUASH_MERGE_END -->

## Testing

- There should be no behavioural changes. squash-merge will switch you back to your default branch if you have done a `bb-pr squash-merge` with no PR number (more logging though).


