### PR TITLE
fix: extra pages causes poor table layout for list operation

### DIFF
--- a/includes/common
+++ b/includes/common
@@ -225,10 +225,12 @@ __bb_rest_with_callback() {
 
 __emit_pr_list() {
   local jq_transform_with_url='.values[]
+    | select(.draft!=true)
     | { "id": (.id | tostring), "title": .title, "url": .links.html.href }
     | "\(.id)|\(.title)|\(.url)"
   '
   local jq_transform_sans_url='.values[]
+    | select(.draft!=true)
     | { "id": (.id | tostring), "title": .title }
     | "\(.id)|\(.title)"
   '

--- a/includes/common
+++ b/includes/common
@@ -256,7 +256,7 @@ __emit_pr_list() {
     results=""
     until [[ "$next" == "null" || "$next" == "" ]]; do
       response=$(__bb_rest_invoke "$next")
-      results+=$(echo "$response" | jq --raw-output "$jq_transform")
+      results+=$(printf "\n%s" "$(echo "$response" | jq --raw-output "$jq_transform")")
       next=$(echo "$response" | jq --raw-output ".next" || true)
     done
 


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Finally hit a situation where we have > 1 page of PRs.

On main you get something like this, if you trigger a bb-list and you have a page2.

```
ID   TITLE                        URL
789  refactor: PR titlexyz        https://bitbucket.org/path.toPR
790  feat(scope): PR title        https://bitbucket.org/path.toPR
801  refactor(scope): PR titlexyz https://bitbucket.org/path.toPR
803  refactor(scope): PR titlexyz https://bitbucket.org/path.toPR
804  feat(scope): PR titlexyz     https://bitbucket.org/path.toPR
805  refactor(scope): PR titlexyz https://bitbucket.org/path.toPR
806  refactor(scope): PR titlexyz https://bitbucket.org/path.toPR
807  refactor(scope): PR title    https://bitbucket.org/path.toPR740 feat(scope): blah https
808  refactor(scope): PR titlexyz https://bitbucket.org/path.toPR
809  refactor(scope): PR titlexyz https://bitbucket.org/path.toPR
```

PR 740 lives on page 2.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- use printf to force a newline
- add JQ selector for non drafts
<!-- SQUASH_MERGE_END -->


## Notes

- Should be no impact on the display since column by default "ignores empty lines" so now it should just be a plain list (740 lives on a newline).
- bb status'tab' for auto complete still works, but no longer displays DRAFT PRs.


